### PR TITLE
Add autoScrollSelect option

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ Each module has options. Some of options are common between modules and some are
 			<td>number</td>
 			<td><code>10</code></td>
 		</tr>
+		<tr>
+			<td><code>autoScrollSelect</code></td>
+			<td>Enable dynamic scrolling in multiple select dropdowns</td>
+			<td>boolean</td>
+			<td><code>true</code></td>
+		</tr>
 	</tbody>
 </table>
 

--- a/js/jcf.select.js
+++ b/js/jcf.select.js
@@ -291,6 +291,7 @@ jcf.addModule(function($, window) {
 				alwaysPreventMouseWheel: true,
 				maxVisibleItems: this.options.maxVisibleItems,
 				useCustomScroll: this.options.useCustomScroll,
+				autoScrollSelect: this.options.autoScrollSelect,
 				holder: this.dropdown.find(this.options.dropContentSelector),
 				multipleSelectWithoutKey: this.realElement.prop('multiple'),
 				element: this.realElement
@@ -573,6 +574,7 @@ jcf.addModule(function($, window) {
 		this.options = $.extend({
 			holder: null,
 			maxVisibleItems: 10,
+			autoScrollSelect: true,
 			selectOnClick: true,
 			useHoverClass: false,
 			useCustomScroll: false,
@@ -772,6 +774,10 @@ jcf.addModule(function($, window) {
 			}
 		},
 		scrollToActiveOption: function() {
+			if(!this.options.autoScrollSelect){
+				return;
+			}
+
 			// scroll to target option
 			var targetOffset = this.getActiveOptionOffset();
 			if (typeof targetOffset === 'number') {


### PR DESCRIPTION
Add option to disable auto scroll in multiple select.

In very long dropdowns, this feature jumps focus to lowest select option
when trying to toggle upper options. Disabling allows toggling of upper
options sequentially.