### PR TITLE
fix select dropdown width

### DIFF
--- a/js/jcf.select.js
+++ b/js/jcf.select.js
@@ -306,7 +306,8 @@ jcf.addModule(function($, window) {
 		},
 		repositionDropdown: function() {
 			var selectOffset = this.fakeElement.offset(),
-				selectWidth = this.fakeElement.outerWidth(),
+				fakeElementBounds = this.fakeElement[0].getBoundingClientRect(),
+				selectWidth = fakeElementBounds.width || fakeElementBounds.right - fakeElementBounds.left,
 				selectHeight = this.fakeElement.outerHeight(),
 				dropHeight = this.dropdown.css('width', selectWidth).outerHeight(),
 				winScrollTop = this.win.scrollTop(),


### PR DESCRIPTION
 It was not the same as select when select itself had the floating-point width (Issue #6)