### PR TITLE
Fixed the number input by increasing the press interval

### DIFF
--- a/js/jcf.number.js
+++ b/js/jcf.number.js
@@ -20,7 +20,7 @@ jcf.addModule(function($) {
 			fakeStructure: '<span class="jcf-number"><span class="jcf-btn-inc"></span><span class="jcf-btn-dec"></span></span>',
 			btnIncSelector: '.jcf-btn-inc',
 			btnDecSelector: '.jcf-btn-dec',
-			pressInterval: 150
+			pressInterval: 300
 		},
 		matchElement: function(element) {
 			return element.is(this.selector);


### PR DESCRIPTION
Hi, I found that the default number form wasn't working correctly with a mousepad. When using the buttons to increase or decrease the value it would jump by 2 values. Eventually I discovered that by doubling the press interval, the problem was solved and it didn't interfere with the form.